### PR TITLE
chore: restore older versions of Node.js for tests

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -17,6 +17,7 @@ jobs:
     strategy:
       matrix:
         node-version: [12.x, 14.x, 16.x, 17.x]
+        eslint-version: [2.13.1, 3, 4, 5, 6, 7, 8]
 
     steps:
     - uses: actions/checkout@v2
@@ -26,6 +27,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - run: npm ci
     - run: npm run build --if-present
+    - run: npm install eslint@${{ eslint-version }}
     - run: npm test
       env:
         CI: true

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [8.x, 10.x, 12.x, 14.x, 16.x, 17.x]
+        node-version: [12.x, 14.x, 16.x, 17.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [6.x, 8.x, 10.x, 12.x, 14.x, 16.x, 17.x]
+        node-version: [8.x, 10.x, 12.x, 14.x, 16.x, 17.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x, 17.x]
+        node-version: [6.x, 8.x, 10.x, 12.x, 14.x, 16.x, 17.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Restore all versions of Node.js that were supported when the last release of this module was published. If any break, we should push a new release semver-major release.