### PR TITLE
chore: test all versions of ESLint that we support

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "standard && c8 --check-coverage --branches 100 --functions 100 --lines 100 node tests/lib/rules/new-with-error.js"
+    "pretest": "standard",
+    "test": "for eslintVersion in 2.13.1 3 4 5 6 7 8; do npm install --no-save eslint@${eslintVersion} && c8 --check-coverage --branches 100 --functions 100 --lines 100 node tests/lib/rules/new-with-error.js || exit 1; done",
+    "posttest": "npm ci"
   },
   "keywords": [
     "eslint",


### PR DESCRIPTION
BREAKING CHANGE: drop support for Node.js < 12.x.