### PR TITLE
chore: drop support for Node.js 12.x

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x, 17.x, 18.x, 19.x]
+        node-version: [14.x, 16.x, 17.x, 18.x, 19.x]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
BREAKING CHANGE: Node.js 14.x or newer is now required